### PR TITLE
Add compile-critical-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following is a list of tools to help generate, inline and report on critical
 * [Penthouse](https://github.com/pocketjoso/penthouse) - by Jonas Ohlsson generates critical-path CSS
 * [Critical](https://github.com/addyosmani/critical) - by Addy Osmani generates & inlines critical-path CSS (uses Penthouse, [Oust](https://github.com/addyosmani/oust) and inline-styles)
 * [CriticalCSS](https://github.com/filamentgroup/criticalcss) - by FilamentGroup finds & outputs critical CSS
+* [compile-critical-css](https://github.com/fengzilong/compile-critical-css) - by Zilong Feng precompile your css to a function that generates critical css dynamically, and the generated function can be used in your NodeJS application runtime
 
 
 ## Server-side modules


### PR DESCRIPTION
Most critical css tools generate static css from static html and static css

But when it comes to SSR, most pages are personalized, and the critical css is dynamically generated according to query parameters or logined user

This is why `compile-critical-css` is created

`compile-critical-css` compiles css string into a function (in build time) like

```js
function ( classlist ) {
  return `generated_css_from_classlist`
}
```

The generated function is dependency-free( without postcss, so less performance impact )

We can import this function in our NodeJS application to extract critical css and inline it into html ( in runtime )